### PR TITLE
Generic car: Add capacity and phaseCount states and settings

### DIFF
--- a/genericcar/integrationplugingenericcar.cpp
+++ b/genericcar/integrationplugingenericcar.cpp
@@ -51,6 +51,8 @@ void IntegrationPluginGenericCar::setupThing(ThingSetupInfo *info)
         } else if (paramTypeId == carSettingsMinChargingCurrentParamTypeId) {
             qCDebug(dcGenericCar()) << "Car minimum charging current settings changed" << value.toUInt() << "A";
             thing->setStateValue(carMinChargingCurrentStateTypeId, value);
+        } else if (paramTypeId == carSettingsPhaseCountParamTypeId) {
+            thing->setStateValue(carPhaseCountStateTypeId, value);
         }
     });
 

--- a/genericcar/integrationplugingenericcar.cpp
+++ b/genericcar/integrationplugingenericcar.cpp
@@ -46,11 +46,16 @@ void IntegrationPluginGenericCar::setupThing(ThingSetupInfo *info)
 
     // Set the min charging current state if the settings value changed
     connect(thing, &Thing::settingChanged, this, [thing](const ParamTypeId &paramTypeId, const QVariant &value){
-        if (paramTypeId == carSettingsMinChargingCurrentParamTypeId) {
+        if (paramTypeId == carSettingsCapacityParamTypeId) {
+            thing->setStateValue(carCapacityStateTypeId, value);
+        } else if (paramTypeId == carSettingsMinChargingCurrentParamTypeId) {
             qCDebug(dcGenericCar()) << "Car minimum charging current settings changed" << value.toUInt() << "A";
             thing->setStateValue(carMinChargingCurrentStateTypeId, value);
         }
     });
+
+    // Migration from earlier versions (pre 1.3) which had the capacity setting as a writable state.
+    thing->setSettingValue(carSettingsCapacityParamTypeId, thing->stateValue(carCapacityStateTypeId));
 
     // Finish the setup
     info->finish(Thing::ThingErrorNoError);
@@ -64,10 +69,7 @@ void IntegrationPluginGenericCar::executeAction(ThingActionInfo *info)
     Thing *thing = info->thing();
     Action action = info->action();
 
-    if (action.actionTypeId() == carCapacityActionTypeId) {
-        thing->setStateValue(carCapacityStateTypeId, action.paramValue(carCapacityActionCapacityParamTypeId));
-        info->finish(Thing::ThingErrorNoError);
-    } else if (action.actionTypeId() == carBatteryLevelActionTypeId) {
+    if (action.actionTypeId() == carBatteryLevelActionTypeId) {
         thing->setStateValue(carBatteryLevelStateTypeId, action.paramValue(carBatteryLevelActionBatteryLevelParamTypeId));
         thing->setStateValue(carBatteryCriticalStateTypeId, action.paramValue(carBatteryLevelActionBatteryLevelParamTypeId).toInt() < 10);
         info->finish(Thing::ThingErrorNoError);

--- a/genericcar/integrationplugingenericcar.json
+++ b/genericcar/integrationplugingenericcar.json
@@ -24,6 +24,16 @@
                             "minValue": 6,
                             "maxValue": 16,
                             "defaultValue": 6
+                        },
+                        {
+                            "id": "57f36386-dd71-4ab0-8d2f-8c74a391f90d",
+                            "name": "capacity",
+                            "displayName": "Capacity",
+                            "type": "uint",
+                            "unit": "KiloWattHour",
+                            "minValue": 5,
+                            "maxValue": 200,
+                            "defaultValue": 50
                         }
                     ],
                     "stateTypes": [
@@ -32,11 +42,9 @@
                             "name": "capacity",
                             "displayName": "Capacity",
                             "displayNameEvent": "Capacity changed",
-                            "displayNameAction": "Set capacity",
                             "type": "double",
                             "unit": "KiloWattHour",
-                            "defaultValue": 50,
-                            "writable": true
+                            "defaultValue": 50
                         },
                         {
                             "id": "d33982d6-6467-4281-b448-68c1b1db088d",

--- a/genericcar/integrationplugingenericcar.json
+++ b/genericcar/integrationplugingenericcar.json
@@ -21,7 +21,7 @@
                             "displayName": "Minimum charging current",
                             "type": "uint",
                             "unit": "Ampere",
-                            "minValue": 6,
+                            "minValue": 4,
                             "maxValue": 16,
                             "defaultValue": 6
                         },

--- a/genericcar/integrationplugingenericcar.json
+++ b/genericcar/integrationplugingenericcar.json
@@ -34,6 +34,15 @@
                             "minValue": 5,
                             "maxValue": 200,
                             "defaultValue": 50
+                        },
+                        {
+                            "id": "6ee1534a-f2c7-4819-8cd5-728dc63a31ba",
+                            "name": "phaseCount",
+                            "displayName": "Phase count",
+                            "type": "uint",
+                            "minValue": 1,
+                            "maxValue": 3,
+                            "defaultValue": 1
                         }
                     ],
                     "stateTypes": [
@@ -77,6 +86,16 @@
                             "minValue": 6,
                             "maxValue": 16,
                             "defaultValue": 6
+                        },
+                        {
+                            "id": "c886c062-bf1a-46c5-8e54-aed804a22d57",
+                            "name": "phaseCount",
+                            "displayName": "Phase count",
+                            "displayNameEvent": "Phase count changed",
+                            "type": "uint",
+                            "minValue": 1,
+                            "maxValue": 3,
+                            "defaultValue": 1
                         }
                     ]
                 }


### PR DESCRIPTION
This allows to configure it also when there's no generic thing view
available and generally seems to make more sense anyways.